### PR TITLE
Code cleanup + use SDK from jitpack

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 repositories {
     mavenLocal()
+    maven("https://jitpack.io")
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
     maven("https://repo.maven.apache.org/maven2/")
@@ -14,12 +15,14 @@ repositories {
 }
 
 dependencies {
+    val sdkVersion = project.property("analyze.sdk.hash")
+
     implementation("net.sf.trove4j:trove4j:3.0.3")
-    implementation("net.analyse:sdk:1.0.3")
+    implementation("com.github.track:sdk:$sdkVersion")
 
     compileOnly("me.clip:placeholderapi:2.11.1")
     compileOnly("org.spigotmc:spigot-api:1.18-R0.1-SNAPSHOT")
-    compileOnly("org.jetbrains:annotations:16.0.2")
+    compileOnly("org.jetbrains:annotations:23.0.0")
 }
 
 group = "net.analyse"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+analyze.sdk.hash=9f3707399a

--- a/src/main/java/net/analyse/plugin/AnalysePlugin.java
+++ b/src/main/java/net/analyse/plugin/AnalysePlugin.java
@@ -27,14 +27,13 @@ public class AnalysePlugin extends JavaPlugin {
     private boolean setup;
     private boolean papiHooked;
 
-    private String serverToken;
     private String encryptionKey;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
 
-        serverToken = getConfig().getString("server.token");
+        final String serverToken = getConfig().getString("server.token");
         encryptionKey = getConfig().getString("encryption-key");
 
         setup = serverToken != null && !serverToken.isEmpty();

--- a/src/main/java/net/analyse/plugin/AnalysePlugin.java
+++ b/src/main/java/net/analyse/plugin/AnalysePlugin.java
@@ -30,8 +30,6 @@ public class AnalysePlugin extends JavaPlugin {
     private String serverToken;
     private String encryptionKey;
 
-    private ServerHeartbeatEvent serverHeartBeatEvent;
-
     @Override
     public void onEnable() {
         saveDefaultConfig();
@@ -46,8 +44,8 @@ public class AnalysePlugin extends JavaPlugin {
         getCommand("analyse").setExecutor(new AnalyseCommand(this));
         Bukkit.getPluginManager().registerEvents(new PlayerActivityListener(this), this);
 
-        serverHeartBeatEvent = new ServerHeartbeatEvent(this);
-        Bukkit.getScheduler().runTaskTimerAsynchronously(this, serverHeartBeatEvent::run, 0, 20 * 10);
+        final ServerHeartbeatEvent serverHeartBeatEvent = new ServerHeartbeatEvent(this);
+        Bukkit.getScheduler().runTaskTimerAsynchronously(this, serverHeartBeatEvent, 0, 20 * 10);
 
         if (encryptionKey == null || encryptionKey.isEmpty()) {
             encryptionKey = generateEncryptionKey(64);
@@ -61,6 +59,7 @@ public class AnalysePlugin extends JavaPlugin {
             getLogger().info("/analyse setup <server-token>");
         } else {
             core = new AnalyseSDK(serverToken, encryptionKey);
+
             try {
                 getLogger().info("Linked Analyse to " + core.getServer().getName() + ".");
             } catch (ServerNotFoundException e) {
@@ -70,9 +69,9 @@ public class AnalysePlugin extends JavaPlugin {
 
         debug("Successfully booted!");
         debug("- Debug Enabled.");
-        debug("- Enabled Stats: " + String.join(", ", Config.ENABLED_STATS));
-        debug("- Excluded Players: " + String.join(", ", Config.EXCLUDED_PLAYERS));
-        debug("- Min Session: " + Config.MIN_SESSION_DURATION);
+        debug("- Enabled Stats: " + String.join(", ", Config.enabledStats));
+        debug("- Excluded Players: " + String.join(", ", Config.excludedPlayers));
+        debug("- Min Session: " + Config.minSessionDuration);
     }
 
     @Override
@@ -114,11 +113,12 @@ public class AnalysePlugin extends JavaPlugin {
     }
 
     public AnalyseSDK setup(String token) {
-        core = new AnalyseSDK(token, encryptionKey);
-        return core;
+        return core = new AnalyseSDK(token, encryptionKey);
     }
 
     public void debug(String message) {
-        if(Config.DEBUG) getLogger().info("DEBUG: " + message);
+        if (Config.debug) {
+            getLogger().info("DEBUG: " + message);
+        }
     }
 }

--- a/src/main/java/net/analyse/plugin/commands/AnalyseCommand.java
+++ b/src/main/java/net/analyse/plugin/commands/AnalyseCommand.java
@@ -40,7 +40,7 @@ public class AnalyseCommand implements CommandExecutor {
                     sender.sendMessage(plugin.parse(String.format(" &b- &7Linked to: &b%s&7.", server.getName())));
                     sender.sendMessage(plugin.parse(String.format(" &b- &7You've used &b%s &7of your &b%s &7quota limit.", server.getCurrentTeamQuota(), server.getTeamQuotaLimit())));
                 } catch (ServerNotFoundException e) {
-                    sender.sendMessage("&b[Analyse] &7The server linked no longer exists.");
+                    sender.sendMessage(plugin.parse("&b[Analyse] &7The server linked no longer exists."));
                     plugin.setSetup(false);
                 }
             } else {

--- a/src/main/java/net/analyse/plugin/commands/subcommands/ReloadCommand.java
+++ b/src/main/java/net/analyse/plugin/commands/subcommands/ReloadCommand.java
@@ -19,17 +19,17 @@ public class ReloadCommand extends SubCommand {
 
         FileConfiguration config = getPlugin().getConfig();
 
-        Config.DEBUG = config.getBoolean("debug", false);
-        Config.EXCLUDED_PLAYERS = config.getStringList("excluded-players");
-        Config.ENABLED_STATS = config.getStringList("enabled-stats");
-        Config.MIN_SESSION_DURATION = config.getInt("minimum-session-duration", 0);
+        Config.debug = config.getBoolean("debug", false);
+        Config.excludedPlayers = config.getStringList("excluded-players");
+        Config.enabledStats = config.getStringList("enabled-stats");
+        Config.minSessionDuration = config.getInt("minimum-session-duration", 0);
 
         sender.sendMessage(plugin.parse("&b[Analyse] &7Reloaded configuration file."));
 
         plugin.debug("Successfully reloaded!");
         plugin.debug("- Debug Enabled.");
-        plugin.debug("- Enabled Stats: " + String.join(", ", Config.ENABLED_STATS));
-        plugin.debug("- Excluded Players: " + String.join(", ", Config.EXCLUDED_PLAYERS));
-        plugin.debug("- Min Session: " + Config.MIN_SESSION_DURATION);
+        plugin.debug("- Enabled Stats: " + String.join(", ", Config.enabledStats));
+        plugin.debug("- Excluded Players: " + String.join(", ", Config.excludedPlayers));
+        plugin.debug("- Min Session: " + Config.minSessionDuration);
     }
 }

--- a/src/main/java/net/analyse/plugin/commands/subcommands/SetupCommand.java
+++ b/src/main/java/net/analyse/plugin/commands/subcommands/SetupCommand.java
@@ -16,7 +16,7 @@ public class SetupCommand extends SubCommand {
 
     @Override
     public void execute(final CommandSender sender, final String[] args) {
-        if(plugin.isSetup()) {
+        if (plugin.isSetup()) {
             sender.sendMessage(plugin.parse("&b[Analyse] &7This server has already been setup."));
             return;
         }

--- a/src/main/java/net/analyse/plugin/listener/PlayerActivityListener.java
+++ b/src/main/java/net/analyse/plugin/listener/PlayerActivityListener.java
@@ -75,7 +75,7 @@ public class PlayerActivityListener implements Listener {
             final Date quitAt = new Date();
             long seconds = (quitAt.getTime()-joinedAt.getTime()) / 1000;
 
-            if(seconds >= Config.minSessionDuration) {
+            if (seconds >= Config.minSessionDuration) {
                 try {
                     plugin.getCore().sendPlayerSession(playerUuid, playerName, joinedAt, domainConnected, playerIp, playerStatistics);
                     plugin.debug(String.format("%s (%s) disconnected, who joined at %s and connected %s with IP of %s", playerName, playerUuid, joinedAt, (domainConnected != null ? "via " + domainConnected : "directly"), playerIp));

--- a/src/main/java/net/analyse/plugin/listener/PlayerActivityListener.java
+++ b/src/main/java/net/analyse/plugin/listener/PlayerActivityListener.java
@@ -28,7 +28,7 @@ public class PlayerActivityListener implements Listener {
     public void onPlayerLogin(final @NotNull PlayerLoginEvent event) {
         if (!plugin.isSetup()) return;
 
-        if (Config.EXCLUDED_PLAYERS.contains(event.getPlayer().getUniqueId().toString())) return;
+        if (Config.excludedPlayers.contains(event.getPlayer().getUniqueId().toString())) return;
 
         plugin.debug("Player connecting via: " + event.getHostname());
 
@@ -37,7 +37,7 @@ public class PlayerActivityListener implements Listener {
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
-        if (Config.EXCLUDED_PLAYERS.contains(event.getPlayer().getUniqueId().toString())) return;
+        if (Config.excludedPlayers.contains(event.getPlayer().getUniqueId().toString())) return;
 
         plugin.debug("Tracking " + event.getPlayer().getName() + " to current time");
         plugin.getActiveJoinMap().put(event.getPlayer().getUniqueId(), new Date());
@@ -47,14 +47,14 @@ public class PlayerActivityListener implements Listener {
     public void onPlayerLeave(PlayerQuitEvent event) {
         if (!plugin.isSetup()) return;
 
-        if (Config.EXCLUDED_PLAYERS.contains(event.getPlayer().getUniqueId().toString())) return;
+        if (Config.excludedPlayers.contains(event.getPlayer().getUniqueId().toString())) return;
 
         final Player player = event.getPlayer();
 
         final List<PlayerStatistic> playerStatistics = new ArrayList<>();
 
         if (plugin.isPapiHooked()) {
-            for (String placeholder : Config.ENABLED_STATS) {
+            for (String placeholder : Config.enabledStats) {
                 String resolvedPlaceholder = PlaceholderAPI.setPlaceholders(player, "%" + placeholder + "%");
 
                 if (!resolvedPlaceholder.equalsIgnoreCase("%" + placeholder + "%")) {
@@ -75,7 +75,7 @@ public class PlayerActivityListener implements Listener {
             final Date quitAt = new Date();
             long seconds = (quitAt.getTime()-joinedAt.getTime()) / 1000;
 
-            if(seconds >= Config.MIN_SESSION_DURATION) {
+            if(seconds >= Config.minSessionDuration) {
                 try {
                     plugin.getCore().sendPlayerSession(playerUuid, playerName, joinedAt, domainConnected, playerIp, playerStatistics);
                     plugin.debug(String.format("%s (%s) disconnected, who joined at %s and connected %s with IP of %s", playerName, playerUuid, joinedAt, (domainConnected != null ? "via " + domainConnected : "directly"), playerIp));
@@ -85,7 +85,7 @@ public class PlayerActivityListener implements Listener {
                 }
             } else {
                 plugin.debug("Skipping sending " + playerName + "'s data as they haven't played for long enough.");
-                plugin.debug("This applies to the 'minimum-session-duration' in your config file (Currently " + Config.MIN_SESSION_DURATION + "s).");
+                plugin.debug("This applies to the 'minimum-session-duration' in your config file (Currently " + Config.minSessionDuration + "s).");
             }
 
             plugin.getActiveJoinMap().remove(player.getUniqueId());

--- a/src/main/java/net/analyse/plugin/util/Config.java
+++ b/src/main/java/net/analyse/plugin/util/Config.java
@@ -10,11 +10,11 @@ public class Config {
 
     private static final @NotNull Configuration config = AnalysePlugin.getPlugin(AnalysePlugin.class).getConfig();
 
-    public static boolean DEBUG = config.getBoolean("debug", false);
+    public static boolean debug = config.getBoolean("debug", false);
 
-    public static List<String> EXCLUDED_PLAYERS = config.getStringList("excluded-players");
+    public static List<String> excludedPlayers = config.getStringList("excluded-players");
 
-    public static List<String> ENABLED_STATS = config.getStringList("enabled-stats");
+    public static List<String> enabledStats = config.getStringList("enabled-stats");
 
-    public static int MIN_SESSION_DURATION = config.getInt("minimum-session-duration", 0);
+    public static int minSessionDuration = config.getInt("minimum-session-duration", 0);
 }

--- a/src/main/java/net/analyse/plugin/util/EncryptUtil.java
+++ b/src/main/java/net/analyse/plugin/util/EncryptUtil.java
@@ -4,17 +4,17 @@ import java.security.SecureRandom;
 import java.util.Random;
 
 public class EncryptUtil {
+
+    private static final Random RANDOM = new SecureRandom();
+    private static final String CHARACTERS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
     // TODO: Could this be replaced with a standardized key generator?
     public static String generateEncryptionKey(int length){
-        String alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-
-        int n = alphabet.length();
-
-        StringBuilder result = new StringBuilder();
-        Random r = new SecureRandom();
+        final int characterLength = CHARACTERS.length();
+        final StringBuilder result = new StringBuilder();
 
         for (int i = 0; i < length; i++)
-            result.append(alphabet.charAt(r.nextInt(n)));
+            result.append(CHARACTERS.charAt(RANDOM.nextInt(characterLength)));
 
         return result.toString();
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,8 +4,10 @@ version: ${version}
 author: "Analyse"
 website: "https://analyse.net"
 description: "Understand your Minecraft audience and monetise your server better."
+
 softdepend:
   - "PlaceholderAPI"
+
 commands:
   analyse:
     description: Main command of the plugin


### PR DESCRIPTION
- Made code design more consistent
- Grab SDK from Jitpack rather than the local maven repository
  - Allow editors to provide their own SDK git hash in the `gradle.properties` file through the `analyze.sdk.hash` property.
- Update JetBrains annotations to 23.0.0