### PR TITLE
Fix Gradle exception

### DIFF
--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -8,8 +8,8 @@ group = rootProject.group
 version = rootProject.version
 
 val javaVersion = JavaVersion.current()
-val ossrhUsername = System.getenv("OSSRH_USERNAME") ?: properties["ossrhUsername"] as String
-val ossrhPassword = System.getenv("OSSRH_PASSWORD") ?: properties["ossrhPassword"] as String
+val ossrhUsername = System.getenv("OSSRH_USERNAME") ?: properties["ossrhUsername"] as String?
+val ossrhPassword = System.getenv("OSSRH_PASSWORD") ?: properties["ossrhPassword"] as String?
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
Fixes an exception thrown by Gradle when building the project without defined OSSRH login credentials

```
FAILURE: Build failed with an exception.

Where:
Build file '/Users/user/IdeaProjects/Analyse/plugin/sdk/build.gradle.kts' line: 11

What went wrong:
null cannot be cast to non-null type kotlin.String
```